### PR TITLE
Adding support for nullable types

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
@@ -46,7 +46,9 @@ namespace XmlDoc2CmdletDoc.Core.Domain
                 switch (MemberInfo.MemberType)
                 {
                     case MemberTypes.Property:
-                        return ((PropertyInfo) MemberInfo).PropertyType;
+                        var type = ((PropertyInfo) MemberInfo).PropertyType;
+                        var innerType = Nullable.GetUnderlyingType(type);
+                        return innerType ?? type;
                     case MemberTypes.Field:
                         return ((FieldInfo) MemberInfo).FieldType;
                     default:

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -74,5 +74,8 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
 
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public ManualClass ValueFromPipelineByPropertyNameParameter { get; set; }
+
+        [Parameter]
+        public int? NullableParameter { get; set; }
     }
 }

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -345,6 +345,24 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
+        public void Command_Parameters_Parameter_NullableType_ForTestManualElements()
+        {
+	        var expectedFullTypeName = typeof(int).FullName;
+	        var expectedTypeName = "int"; // returns the terse type name for this one
+	        var targetName = "NullableParameter";
+
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement("command:parameters/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
+            Assert.That(parameter, Is.Not.Null);
+
+	        var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
+	        Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
+            var shortName = parameter.XPathSelectElement("dev:type/maml:name", resolver);
+	        Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
+        }
+
+        [Test]
         public void Command_InputTypes_ForTestManualElements()
         {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);


### PR DESCRIPTION
**For a parameter of a nullable type, the base code help text displayed:**

```PS> Get-Help Test-ManualElements -param NullableParameter
    -NullableParameter <Nullable`1>```

The revised code will recognize when a parameter is a nullable type and
display the underlying type instead. In the test example that is an integer:

```PS> Get-Help Test-ManualElements -param NullableParameter
    -NullableParameter <int>```

The fact that the type is nullable is typically of no interest to the end-user
so this is a much more useful output.