### PR TITLE
Enum values

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
@@ -144,5 +144,27 @@ namespace XmlDoc2CmdletDoc.Core.Domain
                 }
             }
         }
+
+        /// <summary>
+        /// The list of enumerated value names.
+        /// </summary>
+        public IEnumerable<string> EnumValues
+        {
+            get
+            {
+                var items = new List<string>();
+                if (MemberInfo.MemberType == MemberTypes.Property)
+                {
+                    var type = ParameterType;
+                    if (type.IsEnum)
+                    {
+                        items.AddRange(type
+                            .GetFields(BindingFlags.Public | BindingFlags.Static)
+                            .Select(field => field.Name));
+                    }
+                }
+                return items;
+            }
+        }
     }
 }

--- a/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
@@ -46,7 +46,9 @@ namespace XmlDoc2CmdletDoc.Core.Domain
                 switch (MemberInfo.MemberType)
                 {
                     case MemberTypes.Property:
-                        return ((PropertyInfo) MemberInfo).PropertyType;
+                        var type = ((PropertyInfo) MemberInfo).PropertyType;
+                        var innerType = Nullable.GetUnderlyingType(type);
+                        return innerType ?? type;
                     case MemberTypes.Field:
                         return ((FieldInfo) MemberInfo).FieldType;
                     default:

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -56,6 +56,13 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
     [OutputType(typeof(string))]
     public class TestManualElementsCommand : Cmdlet
     {
+        public enum Importance
+        {
+            Regular,
+            Important,
+            Critical
+        };
+
         /// <summary>
         /// <para type="description">This is part of the MandatoryParameter description.</para>
         /// </summary>
@@ -74,6 +81,9 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
 
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public ManualClass ValueFromPipelineByPropertyNameParameter { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public Importance EnumParameter { get; set; }
 
         [Parameter]
         public int? NullableParameter { get; set; }

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -74,5 +74,8 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
 
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public ManualClass ValueFromPipelineByPropertyNameParameter { get; set; }
+
+        [Parameter]
+        public int? NullableParameter { get; set; }
     }
 }

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -284,6 +284,29 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
+        public void Command_Parameters_Parameter_EnumValues_AddedToParameterValueGroup()
+        {
+            var targetName = "EnumParameter";
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement(
+                "command:syntax/command:syntaxItem/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
+            Assert.That(parameter, Is.Not.Null);
+
+            var valueGroup = parameter.XPathSelectElement("command:parameterValueGroup", resolver);
+            Assert.That(valueGroup, Is.Not.Null);
+
+            var expectedXml =
+@"<command:parameterValueGroup xmlns:command=""http://schemas.microsoft.com/maml/dev/command/2004/10"">
+  <command:parameterValue required=""false"" variableLength=""false"">Regular</command:parameterValue>
+  <command:parameterValue required=""false"" variableLength=""false"">Important</command:parameterValue>
+  <command:parameterValue required=""false"" variableLength=""false"">Critical</command:parameterValue>
+</command:parameterValueGroup>";
+
+            Assert.That(valueGroup.ToSimpleString(), Is.EqualTo(expectedXml));
+        }
+
+        [Test]
         public void Command_Parmeters_Parameter_Description_ForTestManualElements()
         {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
@@ -347,37 +370,37 @@ namespace XmlDoc2CmdletDoc.Tests
         [Test]
         public void Command_Parameters_Parameter_Type_ReportsUnderlyingTypeForNullableType()
         {
-	        var expectedFullTypeName = typeof(int).FullName;
-	        var expectedTypeName = "int"; // returns the terse type name for this one
-	        var targetName = "NullableParameter";
+            var expectedFullTypeName = typeof(int).FullName;
+            var expectedTypeName = "int"; // returns the terse type name for this one
+            var targetName = "NullableParameter";
 
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
 
             var parameter = testManualElementsCommandElement.XPathSelectElement("command:parameters/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
             Assert.That(parameter, Is.Not.Null);
 
-	        var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
-	        Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
+            var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
+            Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
             var shortName = parameter.XPathSelectElement("dev:type/maml:name", resolver);
-	        Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
+            Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
         }
 
         [Test]
         public void Command_Parameters_Parameter_Type_ReportsActualTypeForNonNullableType()
         {
-	        var expectedFullTypeName = typeof(ManualClass).FullName;
-	        var expectedTypeName = typeof(ManualClass).Name;
-	        var targetName = "MandatoryParameter";
+            var expectedFullTypeName = typeof(ManualClass).FullName;
+            var expectedTypeName = typeof(ManualClass).Name;
+            var targetName = "MandatoryParameter";
 
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
 
             var parameter = testManualElementsCommandElement.XPathSelectElement("command:parameters/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
             Assert.That(parameter, Is.Not.Null);
 
-	        var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
-	        Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
+            var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
+            Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
             var shortName = parameter.XPathSelectElement("dev:type/maml:name", resolver);
-	        Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
+            Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
         }
 
         [Test]

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -345,6 +345,24 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
+        public void Command_Parameters_Parameter_NullableType_ForTestManualElements()
+        {
+	        var expectedFullTypeName = typeof(int).FullName;
+	        var expectedTypeName = "int"; // returns the terse type name for this one
+	        var targetName = "NullableParameter";
+
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement("command:parameters/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
+            Assert.That(parameter, Is.Not.Null);
+
+	        var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
+	        Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
+            var shortName = parameter.XPathSelectElement("dev:type/maml:name", resolver);
+	        Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
+        }
+
+        [Test]
         public void Command_InputTypes_ForTestManualElements()
         {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -345,11 +345,29 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
-        public void Command_Parameters_Parameter_NullableType_ForTestManualElements()
+        public void Command_Parameters_Parameter_Type_ReportsUnderlyingTypeForNullableType()
         {
 	        var expectedFullTypeName = typeof(int).FullName;
 	        var expectedTypeName = "int"; // returns the terse type name for this one
 	        var targetName = "NullableParameter";
+
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement("command:parameters/command:parameter[maml:name/text() = '"+targetName+"']", resolver);
+            Assert.That(parameter, Is.Not.Null);
+
+	        var fullName = parameter.XPathSelectElement("command:parameterValue", resolver);
+	        Assert.That(fullName.Value, Is.EqualTo(expectedTypeName));
+            var shortName = parameter.XPathSelectElement("dev:type/maml:name", resolver);
+	        Assert.That(shortName.Value, Is.EqualTo(expectedFullTypeName));
+        }
+
+        [Test]
+        public void Command_Parameters_Parameter_Type_ReportsActualTypeForNonNullableType()
+        {
+	        var expectedFullTypeName = typeof(ManualClass).FullName;
+	        var expectedTypeName = typeof(ManualClass).Name;
+	        var targetName = "MandatoryParameter";
 
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
 


### PR DESCRIPTION
========================================================================
META-NOTE
I put this on a branch, per your comment on my last pull request. 

Note also that this is cumulative to my last pull request... I am new to using git so not sure how to back out the prior commit to give you an isolated set of changes here. :-(

========================================================================
PULL-REQUEST NOTE

This enhances the output in two ways.

(1) Adds enum values adjacent to the parameter name in the syntax summary
Example:

    SYNTAX
       New-TestSetting [[-ValueType] <SettingValueType> {String | XML | Int | Float }]

(2) Adds enum values in the parameter description.
In the example: the "Possible values" line is auto-generated:

    -ValueType <SettingValueType>
       The setting value's type. Defaults to string.
       Possible values: String, XML, Int, Float

Note that this is an enhancement over PowerShell's native cmdlet docs (i.e. it is non-standard), so per your idea on the previous pull request, this could be made a command-line switch if you like.