### PR TITLE
Multiple inputs of same type

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -387,7 +387,7 @@ namespace XmlDoc2CmdletDoc.Core
             var inputTypesElement = new XElement(commandNs + "inputTypes");
             var pipelineParameters = command.GetParameters(ParameterAttribute.AllParameterSets)
                                             .Where(p => p.IsPipeline(ParameterAttribute.AllParameterSets));
-            foreach (var parameter in pipelineParameters.Distinct(p => p.ParameterType))
+            foreach (var parameter in pipelineParameters)
             {
                 inputTypesElement.Add(GenerateInputTypeElement(commentReader, parameter, reportWarning));
             }

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -78,7 +78,7 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
         /// <summary>
         /// <para type="description">OtherValueFromPipeline string parameter is...</para>
         /// </summary>
-        [Parameter(ValueFromPipeline = true)]
+        [Parameter(ValueFromPipelineByPropertyName = true)]
         public string OtherValueFromPipelineParameter { get; set; }
 
         [Parameter(ValueFromPipelineByPropertyName = true)]

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -69,8 +69,17 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
         [Parameter(Position = 1)]
         public string PositionedParameter { get; set; }
 
+        /// <summary>
+        /// <para type="description">ValueFromPipeline string parameter is...</para>
+        /// </summary>
         [Parameter(ValueFromPipeline = true)]
         public string ValueFromPipelineParameter { get; set; }
+
+        /// <summary>
+        /// <para type="description">OtherValueFromPipeline string parameter is...</para>
+        /// </summary>
+        [Parameter(ValueFromPipeline = true)]
+        public string OtherValueFromPipelineParameter { get; set; }
 
         [Parameter(ValueFromPipelineByPropertyName = true)]
         public ManualClass ValueFromPipelineByPropertyNameParameter { get; set; }

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -389,16 +389,27 @@ namespace XmlDoc2CmdletDoc.Tests
                 .XPathSelectElements("command:inputTypes/command:inputType", resolver)
                 .ToList();
             Assert.That(inputTypes, Is.Not.Empty);
-            Assert.That(inputTypes.Count, Is.EqualTo(2));
+            Assert.That(inputTypes.Count, Is.EqualTo(3));
+	        var enumerator = inputTypes.GetEnumerator();
 
             {
-                var inputType = inputTypes.First();
+				enumerator.MoveNext();
+		        var inputType = enumerator.Current;
+                var name = inputType.XPathSelectElement("dev:type/maml:name", resolver);
+                Assert.That(name.Value, Is.EqualTo(typeof(string).FullName));
+            }
+
+			// allow multiple inputs of the same type
+            {
+				enumerator.MoveNext();
+		        var inputType = enumerator.Current;
                 var name = inputType.XPathSelectElement("dev:type/maml:name", resolver);
                 Assert.That(name.Value, Is.EqualTo(typeof(string).FullName));
             }
 
             {
-                var returnValue = inputTypes.Last();
+				enumerator.MoveNext();
+		        var returnValue = enumerator.Current;
                 var type = returnValue.XPathSelectElement("dev:type", resolver);
                 CheckManualClassType(type, true);
 


### PR DESCRIPTION
Add support for multiple inputs of the same type

That is, it is perfectly possible to have two parameters of, e.g., type string
that both have ValueFromPipelineByPropertyName set true.
But the prior code would only list one of those (the first one) under the "INPUTS" section
of the documentation, which is ostensibly the list of *all* inputs that may come from the pipeline.

Note that to be of use, each such parameter would need explicit documentation (which they should have anyway),
because otherwise the description of the type is used as a default,
and if both default then they would show the same description.