### PR TITLE
Add support for auto-documenting parameter aliases

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Parameter.cs
@@ -166,5 +166,19 @@ namespace XmlDoc2CmdletDoc.Core.Domain
                 return Enumerable.Empty<string>();
             }
         }
+
+        /// <summary>
+        /// The list of parameter aliases.
+        /// </summary>
+        public IEnumerable<string> Aliases
+        {
+            get
+            {
+                var aliasAttribute = (AliasAttribute)MemberInfo
+                    .GetCustomAttributes(typeof(AliasAttribute), true)
+                    .FirstOrDefault();
+                return aliasAttribute == null ? new List<string>() : aliasAttribute.AliasNames;
+            }
+        }
     }
 }

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -83,6 +83,21 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
         public ManualClass ValueFromPipelineByPropertyNameParameter { get; set; }
 
         [Parameter(Mandatory = false)]
+        [Alias("Name1A")]
+        public string SingleAliasParameter { get; set; }
+
+        /// <summary>
+        /// <para type="description">Description here.</para>
+        /// </summary>
+        [Parameter(Mandatory = false)]
+        [Alias("Name1B")]
+        public string WithDescriptionAliasParameter { get; set; }
+
+        [Parameter(Mandatory = false)]
+        [Alias("Name1C","Name2C","Name3C")]
+        public string MultipleAliasParameter { get; set; }
+
+        [Parameter(Mandatory = false)]
         public Importance EnumParameter { get; set; }
 
         [Parameter]

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -283,6 +283,43 @@ namespace XmlDoc2CmdletDoc.Tests
             Assert.That(attribute.Value, Is.EqualTo(expectedValue));
         }
 
+        [TestCase("SingleAliasParameter", "Name1A")]
+        [TestCase("WithDescriptionAliasParameter", "Name1B")]
+        [TestCase("MultipleAliasParameter", "Name1C,Name2C,Name3C")]
+        [TestCase("MandatoryParameter", null)]
+        public void Command_Parameters_Parameter_AliasesAttribute(string parameterName, string expectedValue)
+        {
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement(
+                string.Format("command:parameters/command:parameter[maml:name/text() = '{0}']", parameterName), resolver);
+            Assert.That(parameter, Is.Not.Null);
+
+            var attribute = parameter.Attribute("aliases");
+            if (expectedValue == null) { Assert.That(attribute == null); }
+            else { Assert.That(attribute.Value, Is.EqualTo(expectedValue)); }
+        }
+
+        [TestCase("SingleAliasParameter", "Name1A")]
+        [TestCase("WithDescriptionAliasParameter", "Name1B")]
+        [TestCase("MultipleAliasParameter", "Name1C,Name2C,Name3C")]
+        public void Command_Parameters_Parameter_AliasesExistAsParametersWithNote(string parameterName, string aliases)
+        {
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            foreach (var alias in aliases.Split(','))
+            {
+                var parameter = testManualElementsCommandElement.XPathSelectElement(
+                    string.Format(
+                        "command:parameters/command:parameter[maml:name/text() = '{0}']", alias), resolver);
+                Assert.That(parameter, Is.Not.Null);
+
+                var description = parameter.XPathSelectElement("maml:description", resolver);
+                Assert.That(description, Is.Not.Null);
+                Assert.That(description.ToSimpleString(), Is.StringMatching("is an alias of.*" + parameterName));
+            }
+        }
+
         [Test]
         public void Command_Parameters_Parameter_EnumValues_AddedToParameterValueGroup()
         {


### PR DESCRIPTION
Benefits:
1. No longer requires developer to manually document aliases.
2. Each alias is now listed as a first-class parameter when using -Full or -Detailed with Get-Help,
duplicating the content of the true parameter and annotated with a line identifying the true parameter.
3. One could now look up a single parameter's help (with Get-Help <x> -Parameter <y>)
either by the true parameter name or by any of its aliases.