### PR TITLE
Display None for void output type.

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -500,7 +500,7 @@ namespace XmlDoc2CmdletDoc.Core
             var returnValueElement = new XElement(commandNs + "returnValues");
             foreach (var type in command.OutputTypes)
             {
-                returnValueElement.Add(GenerateComment("OutputType: " + type.Name));
+                returnValueElement.Add(GenerateComment("OutputType: " + (type == typeof(void) ? "None" : type.Name)));
                 var returnValueDescription = commentReader.GetOutputTypeDescriptionElement(command, type, reportWarning);
                 returnValueElement.Add(new XElement(commandNs + "returnValue",
                                                     GenerateTypeElement(commentReader, type, returnValueDescription == null, reportWarning),
@@ -558,7 +558,7 @@ namespace XmlDoc2CmdletDoc.Core
         private XElement GenerateTypeElement(ICommentReader commentReader, Type type, bool includeMamlDescription, ReportWarning reportWarning)
         {
             return new XElement(devNs + "type",
-                                new XElement(mamlNs + "name", type.FullName),
+                                new XElement(mamlNs + "name", type == typeof(void) ? "None" : type.FullName),
                                 new XElement(mamlNs + "uri"),
                                 includeMamlDescription ? commentReader.GetTypeDescriptionElement(type, reportWarning) : null);
         }

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -54,6 +54,7 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
     [Cmdlet(VerbsDiagnostic.Test, "ManualElements")]
     [OutputType(typeof(ManualClass))]
     [OutputType(typeof(string))]
+    [OutputType(typeof(void))]
     public class TestManualElementsCommand : Cmdlet
     {
         public enum Importance

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -606,16 +606,22 @@ namespace XmlDoc2CmdletDoc.Tests
                 .XPathSelectElements("command:returnValues/command:returnValue", resolver)
                 .ToList();
             Assert.That(returnValues, Is.Not.Empty);
-            Assert.That(returnValues.Count, Is.EqualTo(2));
+            Assert.That(returnValues.Count, Is.EqualTo(3));
 
             {
-                var returnValue = returnValues.First();
+                var returnValue = returnValues[0];
                 var name = returnValue.XPathSelectElement("dev:type/maml:name", resolver);
                 Assert.That(name.Value, Is.EqualTo(typeof(string).FullName));
             }
 
             {
-                var returnValue = returnValues.Last();
+                var returnValue = returnValues[1];
+                var name = returnValue.XPathSelectElement("dev:type/maml:name", resolver);
+                Assert.That(name.Value, Is.EqualTo("None"));
+            }
+
+            {
+                var returnValue = returnValues[2];
                 var type = returnValue.XPathSelectElement("dev:type", resolver);
                 CheckManualClassType(type, false);
 


### PR DESCRIPTION
Allow a cmdlet to explicitly declare that it doesn't have an output type, with [OutputType(typeof(void)]. In this case, 'None' will be shown in the Outputs part of the cmdlet help text, rather than 'System.Void'.