### PR TITLE
generation of the help file was moved a little bit earlier

### DIFF
--- a/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
     <Target Name="XmlDoc2CmdletDoc"
-            BeforeTargets="AfterBuild"
+            BeforeTargets="PostBuildEvent"
             Inputs="$(TargetPath)"
             Outputs="$(TargetPath)-Help.xml">
         <Exec Condition="'$(XmlDoc2CmdletDocStrict)' == 'false'"


### PR DESCRIPTION
Generation of the help file was moved a little bit earlier to allow developers copy help file somewhere (will be ready to use in "post build event"). PostBuildEvent is just before AfterBuild (which is by default empty).

Nice introduction in stackoverflow
http://stackoverflow.com/questions/6128567/visual-studio-project-file-difference-between-postbuildevent-and-afterbuild-targ
