### PR TITLE
Issue #28: Parameterless Cmdlets generated with empty <command:syntax/> node

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Command.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Command.cs
@@ -99,9 +99,17 @@ namespace XmlDoc2CmdletDoc.Core.Domain
                                                p.ParameterSetNames.Contains(ParameterAttribute.AllParameterSets));
         }
 
-        /// <summary>
-        /// The names of the parameter sets that the parameters belongs to.
-        /// </summary>
-        public IEnumerable<string> ParameterSetNames { get { return Parameters.SelectMany(p => p.ParameterSetNames).Distinct(); } }
+	    /// <summary>
+	    /// The names of the parameter sets that the parameters belongs to.
+	    /// </summary>
+	    public IEnumerable<string> ParameterSetNames
+	    {
+		    get
+		    {
+			    return Parameters.SelectMany(p => p.ParameterSetNames)
+			                     .Union(new[] {ParameterAttribute.AllParameterSets}) //Parameterless cmdlets need this seeded
+			                     .Distinct();
+		    }
+	    }
     }
 }

--- a/XmlDoc2CmdletDoc.sln
+++ b/XmlDoc2CmdletDoc.sln
@@ -1,7 +1,7 @@
 ﻿
-Microsoft Visual Studio Solution File, Format Version 12.00
+Microsoft Visual Studio Solution File, Format Version 14.00
 # Visual Studio 2013
-VisualStudioVersion = 12.0.30110.0
+VisualStudioVersion = 14.0.30110.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XmlDoc2CmdletDoc.Core", "XmlDoc2CmdletDoc.Core\XmlDoc2CmdletDoc.Core.csproj", "{D59BC007-3898-4556-9D8F-6C951BB3E50E}"
 EndProject


### PR DESCRIPTION
Pretty simple fix, augmenting the Command.ParameterSetNames property to return the value of ParameterAttribute.AllParameterSets, at a minimum, if the command has no parameters of its own.