### PR TITLE
Do not include obsolete parameters in the cmdlet doc

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Command.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Command.cs
@@ -62,7 +62,6 @@ namespace XmlDoc2CmdletDoc.Core.Domain
             {
                 var parameters = CmdletType.GetMembers(BindingFlags.Instance | BindingFlags.Public)
                                            .Where(member => member.GetCustomAttributes<ParameterAttribute>().Any())
-                                           .Where(member => !member.GetCustomAttributes<ObsoleteAttribute>().Any())
                                            .Select(member => new Parameter(CmdletType, member));
                 if (typeof(IDynamicParameters).IsAssignableFrom(CmdletType))
                 {

--- a/XmlDoc2CmdletDoc.Core/Domain/Command.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Command.cs
@@ -62,6 +62,7 @@ namespace XmlDoc2CmdletDoc.Core.Domain
             {
                 var parameters = CmdletType.GetMembers(BindingFlags.Instance | BindingFlags.Public)
                                            .Where(member => member.GetCustomAttributes<ParameterAttribute>().Any())
+                                           .Where(member => !member.GetCustomAttributes<ObsoleteAttribute>().Any())
                                            .Select(member => new Parameter(CmdletType, member));
                 if (typeof(IDynamicParameters).IsAssignableFrom(CmdletType))
                 {

--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -323,7 +323,8 @@ namespace XmlDoc2CmdletDoc.Core
         {
             var syntaxItemElement = new XElement(CommandNs + "syntaxItem",
                                                  new XElement(MamlNs + "name", command.Name));
-            foreach (var parameter in command.GetParameters(parameterSetName).OrderBy(p => p.GetPosition(parameterSetName))
+            foreach (var parameter in command.GetParameters(parameterSetName).Where(p => !p.MemberInfo.CustomAttributes.Any(x => x.AttributeType == typeof(ObsoleteAttribute)))
+                                                                             .OrderBy(p => p.GetPosition(parameterSetName))
                                                                              .ThenBy(p => p.IsRequired(parameterSetName) ? "0" : "1")
                                                                              .ThenBy(p => p.Name))
             {

--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -323,8 +323,7 @@ namespace XmlDoc2CmdletDoc.Core
         {
             var syntaxItemElement = new XElement(CommandNs + "syntaxItem",
                                                  new XElement(MamlNs + "name", command.Name));
-            foreach (var parameter in command.GetParameters(parameterSetName).Where(p => !p.MemberInfo.CustomAttributes.Any(x => x.AttributeType == typeof(ObsoleteAttribute)))
-                                                                             .OrderBy(p => p.GetPosition(parameterSetName))
+            foreach (var parameter in command.GetParameters(parameterSetName).OrderBy(p => p.GetPosition(parameterSetName))
                                                                              .ThenBy(p => p.IsRequired(parameterSetName) ? "0" : "1")
                                                                              .ThenBy(p => p.Name))
             {

--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -323,9 +323,10 @@ namespace XmlDoc2CmdletDoc.Core
         {
             var syntaxItemElement = new XElement(CommandNs + "syntaxItem",
                                                  new XElement(MamlNs + "name", command.Name));
-            foreach (var parameter in command.GetParameters(parameterSetName).OrderBy(p => p.GetPosition(parameterSetName)).
-                                                                              ThenBy(p => p.IsRequired(parameterSetName) ? "0" : "1").
-                                                                              ThenBy(p => p.Name))
+            foreach (var parameter in command.GetParameters(parameterSetName).Where(p => !p.MemberInfo.CustomAttributes.Any(x => x.AttributeType == typeof(ObsoleteAttribute)))
+                                                                             .OrderBy(p => p.GetPosition(parameterSetName))
+                                                                             .ThenBy(p => p.IsRequired(parameterSetName) ? "0" : "1")
+                                                                             .ThenBy(p => p.Name))
             {
                 syntaxItemElement.Add(GenerateComment("Parameter: " + parameter.Name));
                 syntaxItemElement.Add(GenerateParameterElement(commentReader, parameter, parameterSetName, reportWarning));

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -1,4 +1,5 @@
-﻿using System.Management.Automation;
+﻿using System;
+using System.Management.Automation;
 
 namespace XmlDoc2CmdletDoc.TestModule.Manual
 {
@@ -112,5 +113,9 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
 
         [Parameter]
         public int? NullableParameter { get; set; }
+
+        [Parameter]
+        [Obsolete]
+        public string ObsoleteParameter { get; set; }
     }
 }

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -1,5 +1,4 @@
-﻿
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Xml;
@@ -222,6 +221,7 @@ namespace XmlDoc2CmdletDoc.Tests
         [TestCase("PositionedParameter")]
         [TestCase("ValueFromPipelineParameter")]
         [TestCase("ValueFromPipelineByPropertyNameParameter")]
+        [TestCase("ObsoleteParameter")] // Obsolete parameters should still have docs, so Get-Help MyCommand -Parameter ObsoleteParameter still works
         public void Command_Parameters_Parameter(string parameterName)
         {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
@@ -230,18 +230,7 @@ namespace XmlDoc2CmdletDoc.Tests
                 $"./command:parameters/command:parameter[maml:name/text() = '{parameterName}']", resolver);
             Assert.That(parameter, Is.Not.Null);
         }
-
-        [Test]
-        public void Command_Parameters_Obsolete()
-        {
-            Assert.That(testManualElementsCommandElement, Is.Not.Null);
-
-            const string parameterName = "ObsoleteParameter";
-
-            var parameter = testManualElementsCommandElement.XPathSelectElement($"./command:parameters/command:parameter[maml:name/text() = '{parameterName}']", resolver);
-            Assert.That(parameter, Is.Null);
-        }
-
+        
         [Test]
         [TestCase("MandatoryParameter", "true")]
         [TestCase("OptionalParameter", "false")]
@@ -903,6 +892,17 @@ If ($thingy -eq $that) {
 @"<maml:description xmlns:maml=""http://schemas.microsoft.com/maml/2004/10"">
   <maml:para>This is the MamlClass description.</maml:para>
 </maml:description>";
+
+        [Test]
+        public void Command_Syntax_Obsolete_Parameters_Are_Excluded()
+        {
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            var syntaxItemParameters = testManualElementsCommandElement.XPathSelectElements("./command:syntax/command:syntaxItem/command:parameter/maml:name", resolver).ToList();
+                
+            Assert.That(syntaxItemParameters, Is.Not.Empty);
+            Assert.That(syntaxItemParameters.Select(x => x.Value).Contains("ObsoleteParameter"), Is.False);
+        }
 
         [Test]
         public void Command_Syntax_Parameters_Ordered_By_Position()

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -232,6 +232,17 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
+        public void Command_Parameters_Obsolete()
+        {
+            Assert.That(testManualElementsCommandElement, Is.Not.Null);
+
+            const string parameterName = "ObsoleteParameter";
+
+            var parameter = testManualElementsCommandElement.XPathSelectElement($"./command:parameters/command:parameter[maml:name/text() = '{parameterName}']", resolver);
+            Assert.That(parameter, Is.Null);
+        }
+
+        [Test]
         [TestCase("MandatoryParameter", "true")]
         [TestCase("OptionalParameter", "false")]
         public void Command_Parameters_Parameter_RequiredAttribute(string parameterName, string expectedValue)


### PR DESCRIPTION
This PR stops outputting obsolete parameters in the cmdlet docs. This may want putting behind a switch, but works as is.