### PR TITLE
Allow excluding parameter sets

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -55,7 +55,7 @@ namespace XmlDoc2CmdletDoc.Core
 
 
                 var document = new XDocument(new XDeclaration("1.0", "utf-8", null),
-                                             GenerateHelpItemsElement(commentReader, cmdletTypes, reportWarning));
+                                             GenerateHelpItemsElement(commentReader, cmdletTypes, reportWarning, options));
 
                 HandleWarnings(options, warnings, assembly);
 
@@ -224,14 +224,15 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="commentReader"></param>
         /// <param name="commands">All of the commands in the module being documented.</param>
         /// <param name="reportWarning">Function used to log warnings.</param>
+        /// <param name="options">The XmlDoc2CmdletDoc options.</param>
         /// <returns>The root-level <em>helpItems</em> element.</returns>
-        private XElement GenerateHelpItemsElement(ICommentReader commentReader, IEnumerable<Command> commands, ReportWarning reportWarning)
+        private XElement GenerateHelpItemsElement(ICommentReader commentReader, IEnumerable<Command> commands, ReportWarning reportWarning, Options options)
         {
             var helpItemsElement = new XElement(MshNs + "helpItems", new XAttribute("schema", "maml"));
             foreach (var command in commands)
             {
                 helpItemsElement.Add(GenerateComment("Cmdlet: " + command.Name));
-                helpItemsElement.Add(GenerateCommandElement(commentReader, command, reportWarning));
+                helpItemsElement.Add(GenerateCommandElement(commentReader, command, reportWarning, options));
             }
             return helpItemsElement;
         }
@@ -242,8 +243,9 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="commentReader"></param>
         /// <param name="command">The command.</param>
         /// <param name="reportWarning">Function used to log warnings.</param>
+        /// <param name="options">The XmlDoc2CmdletDoc options.</param>
         /// <returns>A <em>&lt;command:command&gt;</em> element that represents the <paramref name="command"/>.</returns>
-        private XElement GenerateCommandElement(ICommentReader commentReader, Command command, ReportWarning reportWarning)
+        private XElement GenerateCommandElement(ICommentReader commentReader, Command command, ReportWarning reportWarning, Options options)
         {
             return new XElement(CommandNs + "command",
                                 new XAttribute(XNamespace.Xmlns + "maml", MamlNs),
@@ -251,7 +253,7 @@ namespace XmlDoc2CmdletDoc.Core
                                 new XAttribute(XNamespace.Xmlns + "dev", DevNs),
                                 GenerateDetailsElement(commentReader, command, reportWarning),
                                 GenerateDescriptionElement(commentReader, command, reportWarning),
-                                GenerateSyntaxElement(commentReader, command, reportWarning),
+                                GenerateSyntaxElement(commentReader, command, reportWarning, options.ExcludedParameterSets),
                                 GenerateParametersElement(commentReader, command, reportWarning),
                                 GenerateInputTypesElement(commentReader, command, reportWarning),
                                 GenerateReturnValuesElement(commentReader, command, reportWarning),
@@ -294,8 +296,9 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="commentReader">Provides access to the XML Doc comments.</param>
         /// <param name="command">The command.</param>
         /// <param name="reportWarning">Function used to log warnings.</param>
+        /// <param name="excludedParameterSets">The parameter sets to exclude from the cmdlet XML Help file.</param>
         /// <returns>A <em>&lt;command:syntax&gt;</em> element for the <paramref name="command"/>.</returns>
-        private XElement GenerateSyntaxElement(ICommentReader commentReader, Command command, ReportWarning reportWarning)
+        private XElement GenerateSyntaxElement(ICommentReader commentReader, Command command, ReportWarning reportWarning, ICollection<string> excludedParameterSets)
         {
             var syntaxElement = new XElement(CommandNs + "syntax");
             IEnumerable<string> parameterSetNames = command.ParameterSetNames.ToList();
@@ -303,7 +306,7 @@ namespace XmlDoc2CmdletDoc.Core
             {
                 parameterSetNames = parameterSetNames.Where(name => name != ParameterAttribute.AllParameterSets);
             }
-            foreach (var parameterSetName in parameterSetNames)
+            foreach (var parameterSetName in parameterSetNames.Where(name => !excludedParameterSets.Contains(name)))
             {
                 syntaxElement.Add(GenerateComment("Parameter set: " + parameterSetName));
                 syntaxElement.Add(GenerateSyntaxItemElement(commentReader, command, parameterSetName, reportWarning));

--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -253,7 +253,7 @@ namespace XmlDoc2CmdletDoc.Core
                                 new XAttribute(XNamespace.Xmlns + "dev", DevNs),
                                 GenerateDetailsElement(commentReader, command, reportWarning),
                                 GenerateDescriptionElement(commentReader, command, reportWarning),
-                                GenerateSyntaxElement(commentReader, command, reportWarning, options.ExcludedParameterSets),
+                                GenerateSyntaxElement(commentReader, command, reportWarning, options.IsExcludedParameterSetName),
                                 GenerateParametersElement(commentReader, command, reportWarning),
                                 GenerateInputTypesElement(commentReader, command, reportWarning),
                                 GenerateReturnValuesElement(commentReader, command, reportWarning),
@@ -296,9 +296,9 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="commentReader">Provides access to the XML Doc comments.</param>
         /// <param name="command">The command.</param>
         /// <param name="reportWarning">Function used to log warnings.</param>
-        /// <param name="excludedParameterSets">The parameter sets to exclude from the cmdlet XML Help file.</param>
+        /// <param name="isExcludedParameterSetName">Determines whether or not to exclude a parameter set from the cmdlet XML Help file, based on its name.</param>
         /// <returns>A <em>&lt;command:syntax&gt;</em> element for the <paramref name="command"/>.</returns>
-        private XElement GenerateSyntaxElement(ICommentReader commentReader, Command command, ReportWarning reportWarning, ICollection<string> excludedParameterSets)
+        private XElement GenerateSyntaxElement(ICommentReader commentReader, Command command, ReportWarning reportWarning, Predicate<string> isExcludedParameterSetName)
         {
             var syntaxElement = new XElement(CommandNs + "syntax");
             IEnumerable<string> parameterSetNames = command.ParameterSetNames.ToList();
@@ -306,7 +306,7 @@ namespace XmlDoc2CmdletDoc.Core
             {
                 parameterSetNames = parameterSetNames.Where(name => name != ParameterAttribute.AllParameterSets);
             }
-            foreach (var parameterSetName in parameterSetNames.Where(name => !excludedParameterSets.Contains(name)))
+            foreach (var parameterSetName in parameterSetNames.Where(name => !isExcludedParameterSetName(name)))
             {
                 syntaxElement.Add(GenerateComment("Parameter set: " + parameterSetName));
                 syntaxElement.Add(GenerateSyntaxItemElement(commentReader, command, parameterSetName, reportWarning));

--- a/XmlDoc2CmdletDoc.Core/Options.cs
+++ b/XmlDoc2CmdletDoc.Core/Options.cs
@@ -30,9 +30,11 @@ namespace XmlDoc2CmdletDoc.Core
         public readonly bool TreatWarningsAsErrors;
 
         /// <summary>
-        /// A list of parameter sets that should be excluded from the cmdlet XML Help file.
+        /// A predicate that determines whether a parameter set should be excluded from the
+        /// output help file, based on its name. This is intended to be used for deprecated parameter sets,
+        /// to make them less discoverable.
         /// </summary>
-        public readonly ISet<string> ExcludedParameterSets;
+        public readonly Predicate<string> IsExcludedParameterSetName;
 
         /// <summary>
         /// Creates a new instance with the specified settings.
@@ -40,7 +42,8 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="treatWarningsAsErrors">Indicates whether or not the presence of warnings should be treated as a failure condition.</param>
         /// <param name="assemblyPath">The path of the taget assembly whose XML Doc comments file is to be converted
         /// into a cmdlet XML Help file.</param>
-        /// <param name="excludedParameterSets">A list of parameter sets that should be excluded from the cmdlet XML Help file.
+        /// <param name="isExcludedParameterSetName">A predicate that determines whether a parameter set should be excluded from the
+        /// output help file, based on its name.
         /// This is intended to be used for deprecated parameter sets, to make them less discoverable.</param>
         /// <param name="outputHelpFilePath">The output path of the cmdlet XML Help file.
         /// If <c>null</c>, an appropriate default is selected based on <paramref name="assemblyPath"/>.</param>
@@ -49,7 +52,7 @@ namespace XmlDoc2CmdletDoc.Core
         public Options(
             bool treatWarningsAsErrors,
             string assemblyPath,
-            IReadOnlyCollection<string> excludedParameterSets,
+            Predicate<string> isExcludedParameterSetName = null,
             string outputHelpFilePath = null,
             string docCommentsPath = null)
         {
@@ -59,7 +62,7 @@ namespace XmlDoc2CmdletDoc.Core
 
             AssemblyPath = Path.GetFullPath(assemblyPath);
 
-            ExcludedParameterSets = new HashSet<string>(excludedParameterSets);
+            IsExcludedParameterSetName = isExcludedParameterSetName ?? (_ => false);
 
             OutputHelpFilePath = outputHelpFilePath == null
                                      ? Path.ChangeExtension(AssemblyPath, "dll-Help.xml")
@@ -74,7 +77,6 @@ namespace XmlDoc2CmdletDoc.Core
         /// Provides a string representation of the options, for logging and debug purposes.
         /// </summary>
         public override string ToString() => $"AssemblyPath: {AssemblyPath}, " +
-                                             $"ExcludedParameterSets: {string.Join(", ", ExcludedParameterSets)}" +
                                              $"OutputHelpFilePath: {OutputHelpFilePath}, " +
                                              $"TreatWarningsAsErrors {TreatWarningsAsErrors}";
     }

--- a/XmlDoc2CmdletDoc.Core/Options.cs
+++ b/XmlDoc2CmdletDoc.Core/Options.cs
@@ -30,6 +30,11 @@ namespace XmlDoc2CmdletDoc.Core
         public readonly bool TreatWarningsAsErrors;
 
         /// <summary>
+        /// A list of parameter sets that should be excluded from the cmdlet XML Help file.
+        /// </summary>
+        public readonly IReadOnlyCollection<string> ExcludedParameterSets;
+
+        /// <summary>
         /// Creates a new instance with the specified settings.
         /// </summary>
         /// <param name="treatWarningsAsErrors">Indicates whether or not the presence of warnings should be treated as a failure condition.</param>
@@ -54,6 +59,8 @@ namespace XmlDoc2CmdletDoc.Core
 
             AssemblyPath = Path.GetFullPath(assemblyPath);
 
+            ExcludedParameterSets = excludedParameterSets;
+
             OutputHelpFilePath = outputHelpFilePath == null
                                      ? Path.ChangeExtension(AssemblyPath, "dll-Help.xml")
                                      : Path.GetFullPath(outputHelpFilePath);
@@ -67,6 +74,7 @@ namespace XmlDoc2CmdletDoc.Core
         /// Provides a string representation of the options, for logging and debug purposes.
         /// </summary>
         public override string ToString() => $"AssemblyPath: {AssemblyPath}, " +
+                                             $"ExcludedParameterSets: {string.Join(", ", ExcludedParameterSets)}" +
                                              $"OutputHelpFilePath: {OutputHelpFilePath}, " +
                                              $"TreatWarningsAsErrors {TreatWarningsAsErrors}";
     }

--- a/XmlDoc2CmdletDoc.Core/Options.cs
+++ b/XmlDoc2CmdletDoc.Core/Options.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 
 namespace XmlDoc2CmdletDoc.Core
@@ -34,14 +35,18 @@ namespace XmlDoc2CmdletDoc.Core
         /// <param name="treatWarningsAsErrors">Indicates whether or not the presence of warnings should be treated as a failure condition.</param>
         /// <param name="assemblyPath">The path of the taget assembly whose XML Doc comments file is to be converted
         /// into a cmdlet XML Help file.</param>
+        /// <param name="excludedParameterSets">A list of parameter sets that should be excluded from the cmdlet XML Help file.
+        /// This is intended to be used for deprecated parameter sets, to make them less discoverable.</param>
         /// <param name="outputHelpFilePath">The output path of the cmdlet XML Help file.
         /// If <c>null</c>, an appropriate default is selected based on <paramref name="assemblyPath"/>.</param>
         /// <param name="docCommentsPath">The path of the XML Doc comments file for the target assembly.
         /// If <c>null</c>, an appropriate default is selected based on <paramref name="assemblyPath"/></param>
-        public Options(bool treatWarningsAsErrors,
-                       string assemblyPath,
-                       string outputHelpFilePath = null,
-                       string docCommentsPath = null)
+        public Options(
+            bool treatWarningsAsErrors,
+            string assemblyPath,
+            IReadOnlyCollection<string> excludedParameterSets,
+            string outputHelpFilePath = null,
+            string docCommentsPath = null)
         {
             if (assemblyPath == null) throw new ArgumentNullException(nameof(assemblyPath));
 

--- a/XmlDoc2CmdletDoc.Core/Options.cs
+++ b/XmlDoc2CmdletDoc.Core/Options.cs
@@ -32,7 +32,7 @@ namespace XmlDoc2CmdletDoc.Core
         /// <summary>
         /// A list of parameter sets that should be excluded from the cmdlet XML Help file.
         /// </summary>
-        public readonly IReadOnlyCollection<string> ExcludedParameterSets;
+        public readonly ISet<string> ExcludedParameterSets;
 
         /// <summary>
         /// Creates a new instance with the specified settings.
@@ -59,7 +59,7 @@ namespace XmlDoc2CmdletDoc.Core
 
             AssemblyPath = Path.GetFullPath(assemblyPath);
 
-            ExcludedParameterSets = excludedParameterSets;
+            ExcludedParameterSets = new HashSet<string>(excludedParameterSets);
 
             OutputHelpFilePath = outputHelpFilePath == null
                                      ? Path.ChangeExtension(AssemblyPath, "dll-Help.xml")

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -55,7 +55,7 @@ namespace XmlDoc2CmdletDoc.Tests
             }
 
             // ACT
-            var options = new Options(false, assemblyPath, new string[0]);
+            var options = new Options(false, assemblyPath);
             var engine = new Engine();
             engine.GenerateHelp(options);
 

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -55,7 +55,7 @@ namespace XmlDoc2CmdletDoc.Tests
             }
 
             // ACT
-            var options = new Options(false, assemblyPath);
+            var options = new Options(false, assemblyPath, new string[0]);
             var engine = new Engine();
             engine.GenerateHelp(options);
 

--- a/XmlDoc2CmdletDoc/Program.cs
+++ b/XmlDoc2CmdletDoc/Program.cs
@@ -18,24 +18,42 @@ namespace XmlDoc2CmdletDoc
 
         private static Options ParseArguments(string[] args)
         {
-            const string StrictSwitch = "-strict";
+            const string strictSwitch = "-strict";
 
-            var treatWarningsAsErrors = false;
-            var arguments = args.ToList();
-            if (arguments.Contains(StrictSwitch))
+            try
             {
-                treatWarningsAsErrors = true;
-                arguments.Remove(StrictSwitch);
+                var treatWarningsAsErrors = false;
+                string assemblyPath = null;
+
+                for (var i = 0; i < args.Length; i++)
+                {
+                    if (args[i] == strictSwitch)
+                    {
+                        treatWarningsAsErrors = true;
+                    }
+                    else if (assemblyPath == null)
+                    {
+                        assemblyPath = args[i];
+                    }
+                    else
+                    {
+                        throw new ArgumentException();
+                    }
+                }
+
+                if (assemblyPath == null)
+                {
+                    throw new ArgumentException();
+                }
+
+                return new Options(treatWarningsAsErrors, assemblyPath);
             }
-
-            if (arguments.Count != 1)
+            catch (ArgumentException)
             {
-                Console.Error.WriteLine("Usage: XmlDoc2CmdletDoc.exe [{0}] assemblyPath", StrictSwitch);
+                Console.Error.WriteLine("Usage: XmlDoc2CmdletDoc.exe [{0}] assemblyPath", strictSwitch);
                 Environment.Exit(-1);
+                throw;
             }
-
-            var options = new Options(treatWarningsAsErrors, arguments.First());
-            return options;
         }
     }
 }

--- a/XmlDoc2CmdletDoc/Program.cs
+++ b/XmlDoc2CmdletDoc/Program.cs
@@ -4,13 +4,23 @@ using XmlDoc2CmdletDoc.Core;
 
 namespace XmlDoc2CmdletDoc
 {
-    public class Program
+    public static class Program
     {
         public static void Main(string[] args)
         {
+            var options = ParseArguments(args);
+            Console.WriteLine(options);
+            var engine = new Engine();
+            var exitCode = engine.GenerateHelp(options);
+            Console.WriteLine("GenerateHelp completed with exit code '{0}'", exitCode);
+            Environment.Exit((int)exitCode);
+        }
+
+        private static Options ParseArguments(string[] args)
+        {
             const string StrictSwitch = "-strict";
 
-            bool treatWarningsAsErrors = false;
+            var treatWarningsAsErrors = false;
             var arguments = args.ToList();
             if (arguments.Contains(StrictSwitch))
             {
@@ -23,15 +33,9 @@ namespace XmlDoc2CmdletDoc
                 Console.Error.WriteLine("Usage: XmlDoc2CmdletDoc.exe [{0}] assemblyPath", StrictSwitch);
                 Environment.Exit(-1);
             }
-            else
-            {
-                var options = new Options(treatWarningsAsErrors, arguments.First());
-                Console.WriteLine(options);
-                var engine = new Engine();
-                var exitCode = engine.GenerateHelp(options);
-                Console.WriteLine("GenerateHelp completed with exit code '{0}'", exitCode);
-                Environment.Exit((int)exitCode);
-            }
+
+            var options = new Options(treatWarningsAsErrors, arguments.First());
+            return options;
         }
     }
 }

--- a/XmlDoc2CmdletDoc/Program.cs
+++ b/XmlDoc2CmdletDoc/Program.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using System.Linq;
+using System.Collections.Generic;
 using XmlDoc2CmdletDoc.Core;
 
 namespace XmlDoc2CmdletDoc
@@ -16,20 +16,28 @@ namespace XmlDoc2CmdletDoc
             Environment.Exit((int)exitCode);
         }
 
-        private static Options ParseArguments(string[] args)
+        private static Options ParseArguments(IReadOnlyList<string> args)
         {
             const string strictSwitch = "-strict";
+            const string excludeParameterSetSwitch = "-excludeParameterSet";
 
             try
             {
                 var treatWarningsAsErrors = false;
+                var excludedParameterSets = new List<string>();
                 string assemblyPath = null;
 
-                for (var i = 0; i < args.Length; i++)
+                for (var i = 0; i < args.Count; i++)
                 {
                     if (args[i] == strictSwitch)
                     {
                         treatWarningsAsErrors = true;
+                    }
+                    else if (args[i] == excludeParameterSetSwitch)
+                    {
+                        i++;
+                        if (i >= args.Count) throw new ArgumentException();
+                        excludedParameterSets.Add(args[i]);
                     }
                     else if (assemblyPath == null)
                     {
@@ -46,7 +54,7 @@ namespace XmlDoc2CmdletDoc
                     throw new ArgumentException();
                 }
 
-                return new Options(treatWarningsAsErrors, assemblyPath);
+                return new Options(treatWarningsAsErrors, assemblyPath, excludedParameterSets);
             }
             catch (ArgumentException)
             {

--- a/XmlDoc2CmdletDoc/Program.cs
+++ b/XmlDoc2CmdletDoc/Program.cs
@@ -55,7 +55,7 @@ namespace XmlDoc2CmdletDoc
                     throw new ArgumentException();
                 }
 
-                return new Options(treatWarningsAsErrors, assemblyPath, excludedParameterSets);
+                return new Options(treatWarningsAsErrors, assemblyPath, excludedParameterSets.Contains);
             }
             catch (ArgumentException)
             {

--- a/XmlDoc2CmdletDoc/Program.cs
+++ b/XmlDoc2CmdletDoc/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using XmlDoc2CmdletDoc.Core;
 
 namespace XmlDoc2CmdletDoc
@@ -19,7 +20,7 @@ namespace XmlDoc2CmdletDoc
         private static Options ParseArguments(IReadOnlyList<string> args)
         {
             const string strictSwitch = "-strict";
-            const string excludeParameterSetSwitch = "-excludeParameterSet";
+            const string excludeParameterSetSwitch = "-excludeParameterSets";
 
             try
             {
@@ -37,7 +38,7 @@ namespace XmlDoc2CmdletDoc
                     {
                         i++;
                         if (i >= args.Count) throw new ArgumentException();
-                        excludedParameterSets.Add(args[i]);
+                        excludedParameterSets.AddRange(args[i].Split(new [] {','}, StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim()));
                     }
                     else if (assemblyPath == null)
                     {
@@ -58,7 +59,7 @@ namespace XmlDoc2CmdletDoc
             }
             catch (ArgumentException)
             {
-                Console.Error.WriteLine("Usage: XmlDoc2CmdletDoc.exe [{0}] assemblyPath", strictSwitch);
+                Console.Error.WriteLine($"Usage: XmlDoc2CmdletDoc.exe [{strictSwitch}] [{excludeParameterSetSwitch} parameterSetToExclude1,parameterSetToExclude2] assemblyPath");
                 Environment.Exit(-1);
                 throw;
             }

--- a/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
@@ -9,6 +9,13 @@
         -->
         <XmlDoc2CmdletDocStrict Condition="'$(XmlDoc2CmdletDocStrict)' == ''">false</XmlDoc2CmdletDocStrict>
 
+        <!--
+        Projects that wish to use exclude any parameter sets should add the
+        following to their project file within a <PropertyGroup/> element:
+
+        <XmlDoc2CmdletDocExcludeParameterSets>ParameterSetToExclude1,ParameterSetToExclude2</XmlDoc2CmdletDocExcludeParameterSets>
+        -->
+
         <!-- Determine which platform version of XmlDoc2CmdletDoc.exe to use. -->        
         <XmlDocExeName Condition="'$(PlatformTarget)' == 'x86'">XmlDoc2CmdletDoc32.exe</XmlDocExeName>
         <XmlDocExeName Condition="'$(XmlDocExeName)' == ''">XmlDoc2CmdletDoc.exe</XmlDocExeName>
@@ -18,8 +25,8 @@
             Inputs="$(TargetPath)"
             Outputs="$(TargetPath)-Help.xml">
         <Exec Condition="'$(XmlDoc2CmdletDocStrict)' == 'false'"
-              Command='"$(MSBuildThisFileDirectory)..\tools\$(XmlDocExeName)" "$(TargetPath)"' />
+              Command='"$(MSBuildThisFileDirectory)..\tools\$(XmlDocExeName)" -excludeParameterSets "$(XmlDoc2CmdletDocExcludeParameterSets)" "$(TargetPath)"' />
         <Exec Condition="'$(XmlDoc2CmdletDocStrict)' != 'false'"
-              Command='"$(MSBuildThisFileDirectory)..\tools\$(XmlDocExeName)" -strict "$(TargetPath)"' />
+              Command='"$(MSBuildThisFileDirectory)..\tools\$(XmlDocExeName)" -excludeParameterSets "$(XmlDoc2CmdletDocExcludeParameterSets)" -strict "$(TargetPath)"' />
     </Target>
 </Project>

--- a/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/XmlDoc2CmdletDoc.targets
@@ -10,6 +10,7 @@
         <XmlDoc2CmdletDocStrict Condition="'$(XmlDoc2CmdletDocStrict)' == ''">false</XmlDoc2CmdletDocStrict>
 
         <!--
+        Indicates the names of any parameter sets that should be ignored.
         Projects that wish to use exclude any parameter sets should add the
         following to their project file within a <PropertyGroup/> element:
 


### PR DESCRIPTION
Intention: obsolete/legacy parameter sets can be excluded from the `Get-Help` docs, so they are less discoverable and so don't end up in new code.