### PR TITLE
Implement support for dynamic parameters utilizing RuntimeDefinedParameterDictionary

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Domain/Command.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/Command.cs
@@ -78,8 +78,8 @@ namespace XmlDoc2CmdletDoc.Core.Domain
 
                     if (runtimeParamDictionary != null)
                     {
-                        parameters = parameters.Concat(runtimeParamDictionary
-                                               .Select(member => new RuntimeParameter(CmdletType, member.Value)));
+                        parameters = parameters.Concat(runtimeParamDictionary.Where(member => member.Value.Attributes.OfType<ParameterAttribute>().Any())
+                                                                             .Select(member => new RuntimeParameter(CmdletType, member.Value)));
                     }
                 }
                 return parameters.ToList();

--- a/XmlDoc2CmdletDoc.Core/Domain/ReflectionParameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/ReflectionParameter.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace XmlDoc2CmdletDoc.Core.Domain
+{
+    /// <summary>
+    /// Represents a single parameter of a cmdlet that is identified via reflection.
+    /// </summary>
+    public class ReflectionParameter : Parameter
+    {
+        /// <summary>
+        /// The <see cref="PropertyInfo"/> or <see cref="FieldInfo"/> that defines the property.
+        /// </summary>
+        public readonly MemberInfo MemberInfo;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="cmdletType">The type of the cmdlet the parameter belongs to.</param>
+        /// <param name="memberInfo">The parameter member of the cmdlet. May represent either a field or property.</param>
+        public ReflectionParameter(Type cmdletType, MemberInfo memberInfo) : base(cmdletType, memberInfo?.GetCustomAttributes<ParameterAttribute>())
+        {
+            MemberInfo = memberInfo ?? throw new ArgumentNullException(nameof(memberInfo));
+        }
+
+        /// <summary>
+        /// The name of the parameter.
+        /// </summary>
+        public override string Name => MemberInfo.Name;
+
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override Type ParameterType
+        {
+            get
+            {
+                Type GetType(Type type) => Nullable.GetUnderlyingType(type) ?? type;
+
+                switch (MemberInfo.MemberType)
+                {
+                    case MemberTypes.Property:
+                        return GetType(((PropertyInfo)MemberInfo).PropertyType);
+                    case MemberTypes.Field:
+                        return GetType(((FieldInfo)MemberInfo).FieldType);
+                    default:
+                        throw new NotSupportedException("Unsupported type: " + MemberInfo);
+                }
+            }
+        }
+
+        /// <summary>
+        /// The type of this parameter's member - method, constructor, property, and so on.
+        /// </summary>
+        public override MemberTypes MemberType => MemberInfo.MemberType;
+
+        /// <summary>
+        /// The default value of the parameter. This is obtained by instantiating the cmdlet and accessing the parameter
+        /// property or field to determine its initial value.
+        /// </summary>
+        public override object GetDefaultValue(ReportWarning reportWarning)
+        {
+            var cmdlet = Activator.CreateInstance(_cmdletType);
+            switch (MemberInfo.MemberType)
+            {
+                case MemberTypes.Property:
+                    var propertyInfo = ((PropertyInfo)MemberInfo);
+                    if (!propertyInfo.CanRead)
+                    {
+                        reportWarning(MemberInfo, "Parameter does not have a getter. Unable to determine its default value");
+                        return null;
+                    }
+                    return propertyInfo.GetValue(cmdlet);
+                case MemberTypes.Field:
+                    return ((FieldInfo)MemberInfo).GetValue(cmdlet);
+                default:
+                    throw new NotSupportedException("Unsupported type: " + MemberInfo);
+            }
+        }
+
+        /// <summary>
+        /// Retrieves custom attributes defined on the parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of attribute to retrieve.</typeparam>
+        public override object[] GetCustomAttributes<T>() => MemberInfo.GetCustomAttributes(typeof(T), true);
+    }
+}

--- a/XmlDoc2CmdletDoc.Core/Domain/RuntimeParameter.cs
+++ b/XmlDoc2CmdletDoc.Core/Domain/RuntimeParameter.cs
@@ -1,0 +1,59 @@
+using System;
+using System.Linq;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace XmlDoc2CmdletDoc.Core.Domain
+{
+    /// <summary>
+    /// Represents a single parameter of a cmdlet that is defined at runtime.
+    /// </summary>
+    public class RuntimeParameter : Parameter
+    {
+        /// <summary>
+        /// The <see cref="RuntimeDefinedParameter"/> that defines the property.
+        /// </summary>
+        public readonly RuntimeDefinedParameter RuntimeDefinedParameter;
+
+        /// <summary>
+        /// Creates a new instance.
+        /// </summary>
+        /// <param name="cmdletType">The type of the cmdlet the parameter belongs to.</param>
+        /// <param name="runtimeDefinedParameter">The dynamic runtime parameter member of the cmdlet.</param>
+        public RuntimeParameter(Type cmdletType, RuntimeDefinedParameter runtimeDefinedParameter) : base(cmdletType, runtimeDefinedParameter?.Attributes.OfType<ParameterAttribute>())
+        {
+            RuntimeDefinedParameter = runtimeDefinedParameter ?? throw new ArgumentNullException(nameof(runtimeDefinedParameter));
+        }
+
+        /// <summary>
+        /// The name of the parameter.
+        /// </summary>
+        public override string Name => RuntimeDefinedParameter.Name;
+
+        /// <summary>
+        /// The type of the parameter.
+        /// </summary>
+        public override Type ParameterType => RuntimeDefinedParameter.ParameterType;
+
+        /// <summary>
+        /// The type of this parameter's member - method, constructor, property, and so on.
+        /// </summary>
+        public override MemberTypes MemberType => MemberTypes.Property; //RuntimeDefinedParameters are always defined as a Property
+
+        /// <summary>
+        /// The default value of the parameter. Runtime parameters do not support specifying default values.
+        /// </summary>
+        public override object GetDefaultValue(ReportWarning reportWarning)
+        {
+            //RuntimeDefinedParameter objects cannot have a default value.
+            return null;
+        }
+
+        /// <summary>
+        /// Retrieves custom attributes defined on the parameter.
+        /// </summary>
+        /// <typeparam name="T">The type of attribute to retrieve.</typeparam>
+        public override object[] GetCustomAttributes<T>() =>
+            RuntimeDefinedParameter.Attributes.OfType<T>().Cast<object>().ToArray();
+    }
+}

--- a/XmlDoc2CmdletDoc.Core/Engine.cs
+++ b/XmlDoc2CmdletDoc.Core/Engine.cs
@@ -326,7 +326,7 @@ namespace XmlDoc2CmdletDoc.Core
         {
             var syntaxItemElement = new XElement(CommandNs + "syntaxItem",
                                                  new XElement(MamlNs + "name", command.Name));
-            foreach (var parameter in command.GetParameters(parameterSetName).Where(p => !p.MemberInfo.CustomAttributes.Any(x => x.AttributeType == typeof(ObsoleteAttribute)))
+            foreach (var parameter in command.GetParameters(parameterSetName).Where(p => !p.GetCustomAttributes<ObsoleteAttribute>().Any())
                                                                              .OrderBy(p => p.GetPosition(parameterSetName))
                                                                              .ThenBy(p => p.IsRequired(parameterSetName) ? "0" : "1")
                                                                              .ThenBy(p => p.Name))
@@ -387,11 +387,13 @@ namespace XmlDoc2CmdletDoc.Core
         /// <returns>A <em>&lt;command:parameter&gt;</em> element for the <paramref name="parameter"/>.</returns>
         private XElement GenerateParameterElement(ICommentReader commentReader, Parameter parameter, string parameterSetName, ReportWarning reportWarning)
         {
+            var position = parameter.GetPosition(parameterSetName);
+
             var element = new XElement(CommandNs + "parameter",
                                 new XAttribute("required", parameter.IsRequired(parameterSetName)),
                                 new XAttribute("globbing", parameter.SupportsGlobbing(parameterSetName)),
                                 new XAttribute("pipelineInput", parameter.GetIsPipelineAttribute(parameterSetName)),
-                                new XAttribute("position", parameter.GetPosition(parameterSetName)),
+                                position != null ? new XAttribute("position", position) : null,
                                 new XElement(MamlNs + "name", parameter.Name),
                                 GenerateDescriptionElement(commentReader, parameter, reportWarning),
                                 commentReader.GetParameterValueElement(parameter, reportWarning),

--- a/XmlDoc2CmdletDoc.Core/XmlDoc2CmdletDoc.Core.csproj
+++ b/XmlDoc2CmdletDoc.Core/XmlDoc2CmdletDoc.Core.csproj
@@ -55,6 +55,8 @@
     <Compile Include="Comments\JoltCommentReader.cs" />
     <Compile Include="Domain\Command.cs" />
     <Compile Include="Domain\Parameter.cs" />
+    <Compile Include="Domain\ReflectionParameter.cs" />
+    <Compile Include="Domain\RuntimeParameter.cs" />
     <Compile Include="Engine.cs" />
     <Compile Include="EngineExitCode.cs" />
     <Compile Include="EngineException.cs" />

--- a/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestNestedTypeDynamicParametersCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestNestedTypeDynamicParametersCommand.cs
@@ -3,11 +3,11 @@
 namespace XmlDoc2CmdletDoc.TestModule.DynamicParameters
 {
     /// <summary>
-    /// <para type="synopsis">This is part of the Test-DynamicParameters synopsis.</para>
-    /// <para type="description">This is part of the Test-DynamicParameters description.</para>
+    /// <para type="synopsis">This is part of the Test-NestedTypeDynamicParameters synopsis.</para>
+    /// <para type="description">This is part of the Test-NestedTypeDynamicParameters description.</para>
     /// </summary>
-    [Cmdlet(VerbsDiagnostic.Test, "DynamicParameters")]
-    public class TestDynamicParametersCommand : Cmdlet, IDynamicParameters
+    [Cmdlet(VerbsDiagnostic.Test, "NestedTypeDynamicParameters")]
+    public class TestNestedTypeDynamicParametersCommand : Cmdlet, IDynamicParameters
     {
         /// <summary>
         /// <para type="description">This is part of the StaticParam description.</para>
@@ -15,9 +15,9 @@ namespace XmlDoc2CmdletDoc.TestModule.DynamicParameters
         [Parameter]
         public string StaticParam { get; set; }
 
-        public object GetDynamicParameters() { return new DynamicParameters(); }
+        public object GetDynamicParameters() { return new NestedDynamicParameters(); }
 
-        private class DynamicParameters
+        private class NestedDynamicParameters
         {
             /// <summary>
             /// <para type="description">This is part of the DynamicParam description.</para>

--- a/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestRuntimeDynamicParametersCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestRuntimeDynamicParametersCommand.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Management.Automation;
+
+namespace XmlDoc2CmdletDoc.TestModule.DynamicParameters
+{
+    /// <summary>
+    /// <para type="synopsis">This is part of the Test-RuntimeDynamicParameters synopsis.</para>
+    /// <para type="description">This is part of the Test-RuntimeDynamicParameters description.</para>
+    /// </summary>
+    [Cmdlet(VerbsDiagnostic.Test, "RuntimeDynamicParameters")]
+    public class TestRuntimeDynamicParametersCommand : Cmdlet, IDynamicParameters
+    {
+        /// <summary>
+        /// <para type="description">This is part of the StaticParam description.</para>
+        /// </summary>
+        [Parameter]
+        public string StaticParam { get; set; }
+
+        public object GetDynamicParameters()
+        {
+            var runtimeParamDictionary = new RuntimeDefinedParameterDictionary();
+
+            var attributes = new Collection<Attribute>();
+            attributes.Add(new ParameterAttribute());
+
+            //This parameter has a ParameterAttribute and is considered a dynamic parameter.
+            var dynamicParamWithAttribute = new RuntimeDefinedParameter("DynamicParamWithAttribute", typeof(string), attributes);
+
+            //This parameter is missing a ParameterAttribute, but will still be considered a dynamic parameter.
+            var dynamicParamWithoutAttribute = new RuntimeDefinedParameter("DynamicParamWithoutAttribute", typeof(string), new Collection<Attribute>());
+
+            runtimeParamDictionary.Add("DynamicParamWithAttribute", dynamicParamWithAttribute);
+            runtimeParamDictionary.Add("DynamicParamWithoutAttribute", dynamicParamWithoutAttribute);
+
+            return runtimeParamDictionary;
+        }
+    }
+}

--- a/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestRuntimeDynamicParametersCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/DynamicParameters/TestRuntimeDynamicParametersCommand.cs
@@ -25,13 +25,14 @@ namespace XmlDoc2CmdletDoc.TestModule.DynamicParameters
             attributes.Add(new ParameterAttribute());
 
             //This parameter has a ParameterAttribute and is considered a dynamic parameter.
-            var dynamicParamWithAttribute = new RuntimeDefinedParameter("DynamicParamWithAttribute", typeof(string), attributes);
+            var dynamicParam = new RuntimeDefinedParameter("DynamicParam", typeof(string), attributes);
 
-            //This parameter is missing a ParameterAttribute, but will still be considered a dynamic parameter.
-            var dynamicParamWithoutAttribute = new RuntimeDefinedParameter("DynamicParamWithoutAttribute", typeof(string), new Collection<Attribute>());
+            //This parameter is missing a ParameterAttribute. While it is technically still a dynamic parameter,
+            //it is not considered part of any parameter set and cannot be used.
+            var irrelevantParam = new RuntimeDefinedParameter("IrrelevantParam", typeof(string), new Collection<Attribute>());
 
-            runtimeParamDictionary.Add("DynamicParamWithAttribute", dynamicParamWithAttribute);
-            runtimeParamDictionary.Add("DynamicParamWithoutAttribute", dynamicParamWithoutAttribute);
+            runtimeParamDictionary.Add("DynamicParam", dynamicParam);
+            runtimeParamDictionary.Add("IrrelevantParam", irrelevantParam);
 
             return runtimeParamDictionary;
         }

--- a/XmlDoc2CmdletDoc.TestModule/XmlDoc2CmdletDoc.TestModule.csproj
+++ b/XmlDoc2CmdletDoc.TestModule/XmlDoc2CmdletDoc.TestModule.csproj
@@ -43,7 +43,8 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="DefaultValue\TestDefaultValueCommand.cs" />
-    <Compile Include="DynamicParameters\TestDynamicParametersCommand.cs" />
+    <Compile Include="DynamicParameters\TestNestedTypeDynamicParametersCommand.cs" />
+    <Compile Include="DynamicParameters\TestRuntimeDynamicParametersCommand.cs" />
     <Compile Include="InputTypes\TestInputTypesCommand.cs" />
     <Compile Include="Maml\MamlClass.cs" />
     <Compile Include="Maml\TestMamlElementsCommand.cs" />

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -39,7 +39,8 @@ namespace XmlDoc2CmdletDoc.Tests
         private XElement testInputTypesCommandElement;
         private XElement testPositionedParametersCommandElement;
         private XElement testParameterlessCommandElement;
-        private XElement testDynamicParametersCommandElement;
+        private XElement testNestedTypeDynamicParametersCommandElement;
+        private XElement testRuntimeDynamicParametersCommandElement;
         private XElement testDefaultValueCommandElement;
 
         [SetUp]
@@ -72,7 +73,8 @@ namespace XmlDoc2CmdletDoc.Tests
             testInputTypesCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-InputTypes']", resolver);
             testPositionedParametersCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-PositionedParameters']", resolver);
             testParameterlessCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-Parameterless']", resolver);
-            testDynamicParametersCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-DynamicParameters']", resolver);
+            testNestedTypeDynamicParametersCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-NestedTypeDynamicParameters']", resolver);
+            testRuntimeDynamicParametersCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-RuntimeDynamicParameters']", resolver);
             testDefaultValueCommandElement = rootElement.XPathSelectElement("command:command[command:details/command:name/text() = 'Test-DefaultValue']", resolver);
         }
 
@@ -448,21 +450,39 @@ namespace XmlDoc2CmdletDoc.Tests
         }
 
         [Test]
-        public void Command_Parameters_DynamicParameter()
+        public void Command_Parameters_DynamicParameter_Reflection()
         {
-            Assert.That(testDynamicParametersCommandElement, Is.Not.Null);
+            Assert.That(testNestedTypeDynamicParametersCommandElement, Is.Not.Null);
 
             // We expect the static parameter to be documented.
-            var staticParameter = testDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'StaticParam']", resolver);
+            var staticParameter = testNestedTypeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'StaticParam']", resolver);
             Assert.That(staticParameter, Is.Not.Null);
 
             // We also expect the dynamic parameter to be documented.
-            var dynamicParameter = testDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParam']", resolver);
+            var dynamicParameter = testNestedTypeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParam']", resolver);
             Assert.That(dynamicParameter, Is.Not.Null);
 
             // We don't expect non-parameters on the inner classes to be documented.
-            var irrelevantProperty = testDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'IrrelevantProperty']", resolver);
+            var irrelevantProperty = testNestedTypeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'IrrelevantProperty']", resolver);
             Assert.That(irrelevantProperty, Is.Null);
+        }
+
+        [Test]
+        public void Command_Parameters_DynamicParameter_Runtime()
+        {
+            Assert.That(testRuntimeDynamicParametersCommandElement, Is.Not.Null);
+
+            // We expect the static parameter to be documented.
+            var staticParameter = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'StaticParam']", resolver);
+            Assert.That(staticParameter, Is.Not.Null);
+
+            // We also expect the dynamic parameter containing a ParameterAttribute to be documented.
+            var dynamicParameterWithAttribute = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParamWithAttribute']", resolver);
+            Assert.That(dynamicParameterWithAttribute, Is.Not.Null);
+
+            // We also expect the dynamic parameter without a ParameterAttribute to be documented.
+            var dynamicParameterWithoutAttribute = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParamWithoutAttribute']", resolver);
+            Assert.That(dynamicParameterWithoutAttribute, Is.Not.Null);
         }
 
         [Test]

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -477,12 +477,13 @@ namespace XmlDoc2CmdletDoc.Tests
             Assert.That(staticParameter, Is.Not.Null);
 
             // We also expect the dynamic parameter containing a ParameterAttribute to be documented.
-            var dynamicParameterWithAttribute = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParamWithAttribute']", resolver);
-            Assert.That(dynamicParameterWithAttribute, Is.Not.Null);
+            var dynamicParameter = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParam']", resolver);
+            Assert.That(dynamicParameter, Is.Not.Null);
 
-            // We also expect the dynamic parameter without a ParameterAttribute to be documented.
-            var dynamicParameterWithoutAttribute = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'DynamicParamWithoutAttribute']", resolver);
-            Assert.That(dynamicParameterWithoutAttribute, Is.Not.Null);
+            // We don't expect dynamic parameters missing a ParameterAttribute to be documented, as they
+            // are not part of any parameter set.
+            var irrelevantParameter = testRuntimeDynamicParametersCommandElement.XPathSelectElement("./command:parameters/command:parameter[maml:name/text() = 'IrrelevantParam']", resolver);
+            Assert.That(irrelevantParameter, Is.Null);
         }
 
         [Test]


### PR DESCRIPTION
Issue  #48

* Refactored `Parameter` class into abstract base class
* Implemented new `Parameter` types `ReflectionParameter` and `RuntimeParameter`
* Updated `CommentReaderExtensions` to only read XML comments from `ReflectionParameter` objects
* Renamed `Test-DynamicParameters` cmdlet to `Test-NestedTypeDynamicParameters`
* Implemented new test cmdlet `Test-RuntimeDynamicParameters`
* Implemented `RuntimeDefinedDynamicParameter` tests

I have tested this against my project's module which uses `IDynamicParameters` in a number of locations. The changes work quite well! I have attempted to follow the existing style of the XmlDoc2CmdletDoc code base; please let me know if there are any changes you would like to have implemented