### PR TITLE
Display possible values on parameters that take an IEnumerable<T>

### DIFF
--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Management.Automation;
 
 namespace XmlDoc2CmdletDoc.TestModule.Manual
@@ -110,6 +111,12 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
 
         [Parameter(Mandatory = false)]
         public Importance EnumParameter { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public Importance[] EnumArrayParameter { get; set; }
+
+        [Parameter(Mandatory = false)]
+        public List<Importance> EnumListParameter { get; set; }
 
         [Parameter]
         public int? NullableParameter { get; set; }

--- a/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
+++ b/XmlDoc2CmdletDoc.Tests/AcceptanceTests.cs
@@ -333,6 +333,25 @@ namespace XmlDoc2CmdletDoc.Tests
         public void Command_Parameters_Parameter_EnumValues_AddedToParameterValueGroup()
         {
             var targetName = "EnumParameter";
+            CheckEnumParameterValues(targetName);
+        }
+
+        [Test]
+        public void Command_Parameters_Parameter_EnumArrayValues_AddedToParameterValueGroup()
+        {
+            var targetName = "EnumArrayParameter";
+            CheckEnumParameterValues(targetName);
+        }
+
+        [Test]
+        public void Command_Parameters_Parameter_EnumListValues_AddedToParameterValueGroup()
+        {
+            var targetName = "EnumListParameter";
+            CheckEnumParameterValues(targetName);
+        }
+
+        private void CheckEnumParameterValues(string targetName)
+        {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
 
             var parameter = testManualElementsCommandElement.XPathSelectElement(
@@ -920,7 +939,7 @@ If ($thingy -eq $that) {
             Assert.That(testManualElementsCommandElement, Is.Not.Null);
 
             var syntaxItemParameters = testManualElementsCommandElement.XPathSelectElements("./command:syntax/command:syntaxItem/command:parameter/maml:name", resolver).ToList();
-                
+
             Assert.That(syntaxItemParameters, Is.Not.Empty);
             Assert.That(syntaxItemParameters.Select(x => x.Value).Contains("ObsoleteParameter"), Is.False);
         }


### PR DESCRIPTION
Issue #42

This pull request updates the `EnumValues` member of the `Parameter` class to return a list of all possible enum values when the `ParameterType` is either an enum value or an `IEnumerable<T>` where `T` is an enum value.

Tests are included for the common case of having an array as well as the less common case of having an arbitrary type that explicitly implements `IEnumerable<T>`.