### PR TITLE
Include type descriptions for array-typed parameters

### DIFF
--- a/XmlDoc2CmdletDoc.Core/Extensions/CommentReaderExtensions.cs
+++ b/XmlDoc2CmdletDoc.Core/Extensions/CommentReaderExtensions.cs
@@ -363,6 +363,9 @@ namespace XmlDoc2CmdletDoc.Core.Extensions
         /// <returns>A description for the type, or null if no description is available.</returns>
         public static XElement GetTypeDescriptionElement(this ICommentReader commentReader, Type type, ReportWarning reportWarning)
         {
+            if (type.IsArray)
+                type = type.GetElementType();
+
             var commentsElement = commentReader.GetComments(type);
             return GetMamlDescriptionElementFromXmlDocComment(commentsElement, "description", warningText => reportWarning(type, warningText));
         }

--- a/XmlDoc2CmdletDoc.TestModule/Maml/TestMamlElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Maml/TestMamlElementsCommand.cs
@@ -36,6 +36,15 @@ namespace XmlDoc2CmdletDoc.TestModule.Maml
         [Parameter]
         public MamlClass CommonParameter { get; set; }
 
+        /// <summary xmlns:maml="http://schemas.microsoft.com/maml/2004/10">
+        /// This text shouldn't appear in the cmldet help.
+        /// <maml:description type="description">
+        ///   <maml:para>This is the ArrayParameter description.</maml:para>
+        /// </maml:description>
+        /// </summary>
+        [Parameter]
+        public MamlClass[] ArrayParameter { get; set; }
+
         [Parameter(ParameterSetName = "One", ValueFromPipeline = true)]
         public string ParameterOne { get; set; }
 

--- a/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
+++ b/XmlDoc2CmdletDoc.TestModule/Manual/TestManualElementsCommand.cs
@@ -73,6 +73,13 @@ namespace XmlDoc2CmdletDoc.TestModule.Manual
         [Parameter(Mandatory = true)]
         public ManualClass MandatoryParameter { get; set; }
 
+        /// <summary>
+        /// <para type="description">This is part of the ArrayParameter description.</para>
+        /// </summary>
+        /// <para type="description">This is also part of the ArrayParameter description.</para>
+        [Parameter(Mandatory = true)]
+        public ManualClass[] ArrayParameter { get; set; }
+
         [Parameter(Mandatory = false)]
         public string OptionalParameter { get; set; }
 


### PR DESCRIPTION
This pull request fixes an issue wherein XmlDoc2CmdletDoc will not include type descriptions for parameter type when the type is defined as an array (resulting in a warning that the type is missing a comment/description)

```c#
/// <summary>
/// <para type="description">blah</para>
/// </summary>
class Foo
{
}

class Test : Cmdlet
{
    // OK
    [Parameter]
    public Foo OK { get; set; }

    // Warning: Foo[]: No XML doc comment found, No description comment found
    [Parameter]
    public Foo[] NotOK { get; set; }
}
```

This PR also refactors the contents of the `Command_Parmeters_Parameter_Type_ForTestManualElements` and `Command_Parmeters_Parameter_Type_ForTestMamlElements` methods into a common method suitable for testing both of these scenarios with and without array types
