### PR TITLE
Fix for malformed command on build.

### DIFF
--- a/XmlDoc2CmdletDoc/build/net461/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/build/net461/XmlDoc2CmdletDoc.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="'XmlDoc2CmdletDocToolPath' == ''">
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' != 'x86'">net461\XmlDoc2CmdletDoc.exe</XmlDoc2CmdletDocToolPath>
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' == 'x86'">net461\XmlDoc2CmdletDoc32.exe</XmlDoc2CmdletDocToolPath>
+    <PropertyGroup Condition="'$(XmlDocToolsPath)' == ''">
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' != 'x86'">net461\XmlDoc2CmdletDoc.exe</XmlDocToolsPath>
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' == 'x86'">net461\XmlDoc2CmdletDoc32.exe</XmlDocToolsPath>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)..\XmlDoc2CmdletDoc.targets" />
 </Project>

--- a/XmlDoc2CmdletDoc/build/net472/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/build/net472/XmlDoc2CmdletDoc.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="'XmlDoc2CmdletDocToolPath' == ''">
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' != 'x86'">net472\XmlDoc2CmdletDoc.exe</XmlDoc2CmdletDocToolPath>
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' == 'x86'">net472\XmlDoc2CmdletDoc32.exe</XmlDoc2CmdletDocToolPath>
+    <PropertyGroup Condition="'$(XmlDocToolsPath)' == ''">
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' != 'x86'">net472\XmlDoc2CmdletDoc.exe</XmlDocToolsPath>
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' == 'x86'">net472\XmlDoc2CmdletDoc32.exe</XmlDocToolsPath>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)..\XmlDoc2CmdletDoc.targets" />
 </Project>

--- a/XmlDoc2CmdletDoc/build/net48/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/build/net48/XmlDoc2CmdletDoc.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="'XmlDoc2CmdletDocToolPath' == ''">
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' != 'x86'">net48\XmlDoc2CmdletDoc.exe</XmlDoc2CmdletDocToolPath>
-        <XmlDoc2CmdletDocToolPath Condition="'$(PlatformTarget)' == 'x86'">net48\XmlDoc2CmdletDoc32.exe</XmlDoc2CmdletDocToolPath>
+    <PropertyGroup Condition="'$(XmlDocToolsPath)' == ''">
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' != 'x86'">net48\XmlDoc2CmdletDoc.exe</XmlDocToolsPath>
+        <XmlDocToolsPath Condition="'$(PlatformTarget)' == 'x86'">net48\XmlDoc2CmdletDoc32.exe</XmlDocToolsPath>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)..\XmlDoc2CmdletDoc.targets" />
 </Project>

--- a/XmlDoc2CmdletDoc/build/netcoreapp2.1/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/build/netcoreapp2.1/XmlDoc2CmdletDoc.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="'XmlDoc2CmdletDocToolPath' == ''">
-        <XmlDoc2CmdletDocToolPath>netcoreapp2.1\XmlDoc2CmdletDoc.dll</XmlDoc2CmdletDocToolPath>
+    <PropertyGroup Condition="'$(XmlDocToolsPath)' == ''">
+        <XmlDocToolsPath>netcoreapp2.1\XmlDoc2CmdletDoc.dll</XmlDocToolsPath>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)..\XmlDoc2CmdletDoc.targets" />
 </Project>

--- a/XmlDoc2CmdletDoc/build/netcoreapp3.1/XmlDoc2CmdletDoc.targets
+++ b/XmlDoc2CmdletDoc/build/netcoreapp3.1/XmlDoc2CmdletDoc.targets
@@ -1,6 +1,6 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-    <PropertyGroup Condition="'XmlDoc2CmdletDocToolPath' == ''">
-        <XmlDoc2CmdletDocToolPath>netcoreapp3.1\XmlDoc2CmdletDoc.dll</XmlDoc2CmdletDocToolPath>
+    <PropertyGroup Condition="'$(XmlDocToolsPath)' == ''">
+        <XmlDocToolsPath>netcoreapp3.1\XmlDoc2CmdletDoc.dll</XmlDocToolsPath>
     </PropertyGroup>
     <Import Project="$(MSBuildThisFileDirectory)..\XmlDoc2CmdletDoc.targets" />
 </Project>


### PR DESCRIPTION
Originally the 'XmlDoc2CmdletDoc' target would try to execute the command without the executable/binary file path at the start e.g.: 
"-strict [ProjectBinaryFilePath]"

This PR fixes this command to take the correct format:
"[XmlDoc2CmdletDocToolPath] -strict [ProjectBinaryFilePath]"